### PR TITLE
Optimize the "Hash" and make it faster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/panmari/cuckoofilter
 go 1.15
 
 require (
-	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165
-	github.com/google/go-cmp v0.5.9
+        github.com/google/go-cmp v0.5.9
+        github.com/zeebo/wyhash v0.0.2-0.20221101160656-7c89dcff99fa
+        github.com/zeebo/xxh3 v1.0.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 h1:BS21ZUJ/B5X2UVUbczfmdWH7GapPWAhxcMsDnjJTU1E=
-github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
+github.com/zeebo/wyhash v0.0.2-0.20221101160656-7c89dcff99fa h1:icNAX4PdeSmRwz4fmsMSUmYSPz+agsgrEe67BFrLFBM=
+github.com/zeebo/wyhash v0.0.2-0.20221101160656-7c89dcff99fa/go.mod h1:Ti+OwfNtM5AZiYAL0kOPIfliqDP5c0VtOnnMAqzuuZk=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/wyhash v0.0.2-0.20221101160656-7c89dcff99fa h1:icNAX4PdeSmRwz4fmsMSUmYSPz+agsgrEe67BFrLFBM=
 github.com/zeebo/wyhash v0.0.2-0.20221101160656-7c89dcff99fa/go.mod h1:Ti+OwfNtM5AZiYAL0kOPIfliqDP5c0VtOnnMAqzuuZk=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/util.go
+++ b/util.go
@@ -9,13 +9,14 @@ import (
 )
 
 var (
-	altHash = [maxFingerprint]uint{}
+	// plus 1 to prevent out of range.
+	altHash = [maxFingerprint + 1]uint{}
 	rng     wyhash.SRNG
 )
 
 // randi returns either i1 or i2 randomly.
 func randi(i1, i2 uint) uint {
-	// it's faster than mod, but the result is almost same.
+	// it's faster than mod, but the result is the almost same.
 	if uint32(uint64(uint32(rng.Uint64()))*uint64(2)>>32) == 0 {
 		return i1
 	}
@@ -33,7 +34,7 @@ func getEndian() (endian binary.ByteOrder) {
 func init() {
 	b := make([]byte, 2)
 	endian := getEndian()
-	for i := 0; i < maxFingerprint; i++ {
+	for i := 0; i < maxFingerprint+1; i++ {
 		endian.PutUint16(b, uint16(i))
 		altHash[i] = (uint(xxh3.Hash(b)))
 	}

--- a/util.go
+++ b/util.go
@@ -2,24 +2,45 @@ package cuckoo
 
 import (
 	"encoding/binary"
-	"math/rand"
+	"unsafe"
 
-	metro "github.com/dgryski/go-metro"
+	"github.com/zeebo/wyhash"
+	"github.com/zeebo/xxh3"
+)
+
+var (
+	altHash [maxFingerprint]uint
+	rng     wyhash.SRNG
 )
 
 // randi returns either i1 or i2 randomly.
 func randi(i1, i2 uint) uint {
-	if rand.Int31()%2 == 0 {
+	// it's faster than mod, but the result is almost same.
+	if uint32(uint64(uint32(rng.Uint64()))*uint64(2)>>32) == 0 {
 		return i1
 	}
 	return i2
 }
+func getEndian() (endian binary.ByteOrder) {
+	var i int = 0x1
+	bs := (*[int(unsafe.Sizeof(0))]byte)(unsafe.Pointer(&i))
+	if bs[0] == 0 {
+		return binary.BigEndian
+	} else {
+		return binary.LittleEndian
+	}
+}
+func init() {
+	b := make([]byte, 2)
+	endian := getEndian()
+	for i := 0; i < maxFingerprint; i++ {
+		endian.PutUint16(b, uint16(i))
+		altHash[i] = (uint(xxh3.Hash(b)))
+	}
+}
 
 func getAltIndex(fp fingerprint, i uint, bucketIndexMask uint) uint {
-	b := make([]byte, 2)
-	binary.LittleEndian.PutUint16(b, uint16(fp))
-	hash := uint(metro.Hash64(b, 1337))
-	return (i ^ hash) & bucketIndexMask
+	return (i ^ altHash[fp]) & bucketIndexMask
 }
 
 func getFingerprint(hash uint64) fingerprint {
@@ -32,7 +53,7 @@ func getFingerprint(hash uint64) fingerprint {
 
 // getIndexAndFingerprint returns the primary bucket index and fingerprint to be used
 func getIndexAndFingerprint(data []byte, bucketIndexMask uint) (uint, fingerprint) {
-	hash := metro.Hash64(data, 1337)
+	hash := xxh3.Hash(data)
 	f := getFingerprint(hash)
 	// Use least significant bits for deriving index.
 	i1 := uint(hash) & bucketIndexMask

--- a/util.go
+++ b/util.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	altHash [maxFingerprint]uint
+	altHash = [maxFingerprint]uint{}
 	rng     wyhash.SRNG
 )
 


### PR DESCRIPTION
github.com/seiflotfy/cuckoofilter first calculate the hash when it's in initialization.

And I try this to optimize this "better" version of cuckoofilter.

Test is all passed.
```
=== RUN   TestBucket_Reset
--- PASS: TestBucket_Reset (0.00s)
=== RUN   TestInsertion
--- PASS: TestInsertion (0.03s)
=== RUN   TestLookup
=== RUN   TestLookup/cf.Lookup("one")
=== PAUSE TestLookup/cf.Lookup("one")
=== RUN   TestLookup/cf.Lookup("two")
=== PAUSE TestLookup/cf.Lookup("two")
=== RUN   TestLookup/cf.Lookup("three")
=== PAUSE TestLookup/cf.Lookup("three")
=== RUN   TestLookup/cf.Lookup("four")
=== PAUSE TestLookup/cf.Lookup("four")
=== RUN   TestLookup/cf.Lookup("five")
=== PAUSE TestLookup/cf.Lookup("five")
=== CONT  TestLookup/cf.Lookup("one")
=== CONT  TestLookup/cf.Lookup("four")
=== CONT  TestLookup/cf.Lookup("five")
=== CONT  TestLookup/cf.Lookup("three")
=== CONT  TestLookup/cf.Lookup("two")
--- PASS: TestLookup (0.00s)
    --- PASS: TestLookup/cf.Lookup("one") (0.00s)
    --- PASS: TestLookup/cf.Lookup("four") (0.00s)
    --- PASS: TestLookup/cf.Lookup("five") (0.00s)
    --- PASS: TestLookup/cf.Lookup("three") (0.00s)
    --- PASS: TestLookup/cf.Lookup("two") (0.00s)
=== RUN   TestFilter_LookupLarge
--- PASS: TestFilter_LookupLarge (0.09s)
=== RUN   TestFilter_Insert
--- PASS: TestFilter_Insert (0.00s)
=== RUN   TestDelete
=== RUN   TestDelete/cf.Delete("four")
=== RUN   TestDelete/cf.Delete("five")
=== RUN   TestDelete/cf.Delete("one")
=== RUN   TestDelete/cf.Delete("two")
=== RUN   TestDelete/cf.Delete("three")
--- PASS: TestDelete (0.00s)
    --- PASS: TestDelete/cf.Delete("four") (0.00s)
    --- PASS: TestDelete/cf.Delete("five") (0.00s)
    --- PASS: TestDelete/cf.Delete("one") (0.00s)
    --- PASS: TestDelete/cf.Delete("two") (0.00s)
    --- PASS: TestDelete/cf.Delete("three") (0.00s)
=== RUN   TestDeleteMultipleSame
    cuckoofilter_test.go:229: Filter state full: &{[[65037 65037 65037 65037] [65037 0 0 0]] 5 1}
=== RUN   TestDeleteMultipleSame/cf.Delete("missing")
=== RUN   TestDeleteMultipleSame/cf.Delete("missing2")
=== RUN   TestDeleteMultipleSame/cf.Delete("some_item")
=== RUN   TestDeleteMultipleSame/cf.Delete("some_item")#01
=== RUN   TestDeleteMultipleSame/cf.Delete("some_item")#02
=== RUN   TestDeleteMultipleSame/cf.Delete("some_item")#03
=== RUN   TestDeleteMultipleSame/cf.Delete("some_item")#04
=== RUN   TestDeleteMultipleSame/cf.Delete("some_item")#05
--- PASS: TestDeleteMultipleSame (0.00s)
    --- PASS: TestDeleteMultipleSame/cf.Delete("missing") (0.00s)
    --- PASS: TestDeleteMultipleSame/cf.Delete("missing2") (0.00s)
    --- PASS: TestDeleteMultipleSame/cf.Delete("some_item") (0.00s)
    --- PASS: TestDeleteMultipleSame/cf.Delete("some_item")#01 (0.00s)
    --- PASS: TestDeleteMultipleSame/cf.Delete("some_item")#02 (0.00s)
    --- PASS: TestDeleteMultipleSame/cf.Delete("some_item")#03 (0.00s)
    --- PASS: TestDeleteMultipleSame/cf.Delete("some_item")#04 (0.00s)
    --- PASS: TestDeleteMultipleSame/cf.Delete("some_item")#05 (0.00s)
=== RUN   TestEncodeDecode
--- PASS: TestEncodeDecode (0.00s)
=== RUN   TestIndexAndFP
--- PASS: TestIndexAndFP (0.00s)
=== RUN   FuzzDecode
=== RUN   FuzzDecode/seed#0
--- PASS: FuzzDecode (0.00s)
    --- PASS: FuzzDecode/seed#0 (0.00s)
=== RUN   Example
--- PASS: Example (0.00s)
=== RUN   ExampleFilter_Lookup
--- PASS: ExampleFilter_Lookup (0.00s)
=== RUN   ExampleFilter_Delete
--- PASS: ExampleFilter_Delete (0.00s)
=== RUN   Example_threadSafe
--- PASS: Example_threadSafe (0.00s)

```

Here is the benchmark result:

Before optimization:
```
BenchmarkFilter_Reset
BenchmarkFilter_Reset-8    	   97090	     12767 ns/op
BenchmarkFilter_Insert
BenchmarkFilter_Insert-8   	39633634	        30.11 ns/op
BenchmarkFilter_Lookup
BenchmarkFilter_Lookup-8   	37294400	        31.90 ns/op
PASS
```

After optimization:
```
BenchmarkFilter_Reset
BenchmarkFilter_Reset-8    	   97978	     12345 ns/op
BenchmarkFilter_Insert
BenchmarkFilter_Insert-8   	54499240	        22.14 ns/op
BenchmarkFilter_Lookup
BenchmarkFilter_Lookup-8   	57099548	        20.85 ns/op
PASS
```

github.com/seiflotfy/cuckoofilter(The benchmark file has been replaced by the same.):
```
BenchmarkFilter_Insert
BenchmarkFilter_Insert-8   	38737519	        29.49 ns/op
BenchmarkFilter_Lookup
BenchmarkFilter_Lookup-8   	44468107	        27.07 ns/op
BenchmarkFilter_Reset
BenchmarkFilter_Reset-8    	   97950	     12242 ns/op
PASS
```
