### PR TITLE
improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Cuckoo Filter
 
-[![GitHub go.mod Go version of a Go module](https://img.shields.io/github/go-mod/go-version/panmari/cuckoofilter.svg)](https://github.com/panmari/cuckoofilter)
-[![GoDoc](https://godoc.org/github.com/panmari/cuckoofilter?status.svg)](https://godoc.org/github.com/panmari/cuckoofilter)
-[![GoReportCard](https://goreportcard.com/badge/github.com/panmari/cuckoofilter)](https://goreportcard.com/report/github.com/panmari/cuckoofilter)
+[![GitHub go.mod Go version of a Go module](https://img.shields.io/github/go-mod/go-version/livekit/cuckoofilter.svg)](https://github.com/livekit/cuckoofilter)
+[![GoDoc](https://godoc.org/github.com/livekit/cuckoofilter?status.svg)](https://godoc.org/github.com/livekit/cuckoofilter)
+[![GoReportCard](https://goreportcard.com/badge/github.com/livekit/cuckoofilter)](https://goreportcard.com/report/github.com/livekit/cuckoofilter)
 
 Well-tuned, production-ready cuckoo filter that performs best in class for low false positive rates (at around 0.01%). For details, see [full evaluation](https://panmari.github.io/2020/10/09/probabilistic-filter-golang.html).
 
@@ -35,7 +35,7 @@ With the 16 bit fingerprint size in this repository, you can expect `r ~= 0.0001
 import (
 	"fmt"
 
-	cuckoo "github.com/panmari/cuckoofilter"
+	cuckoo "github.com/livekit/cuckoofilter"
 )
 
 func Example() {
@@ -57,6 +57,6 @@ func Example() {
 }
 ```
 
-For more examples, see [the example tests](https://github.com/panmari/cuckoofilter/blob/master/example_test.go).
-Operations on a filter are not thread safe by default. 
+For more examples, see [the example tests](https://github.com/livekit/cuckoofilter/blob/master/example_test.go).
+Operations on a filter are not thread safe by default.
 See [this example](example_threadsafe_test.go) for using the filter concurrently.

--- a/bucket.go
+++ b/bucket.go
@@ -3,16 +3,16 @@ package cuckoo
 import (
 	"bytes"
 	"fmt"
+	"math/bits"
 )
 
 // fingerprint represents a single entry in a bucket.
 type fingerprint uint16
 
 // bucket keeps track of fingerprints hashing to the same index.
-type bucket [bucketSize]fingerprint
+type bucket uint64
 
 const (
-	nullFp              = 0
 	bucketSize          = 4
 	fingerprintSizeBits = 16
 	maxFingerprint      = (1 << fingerprintSizeBits) - 1
@@ -21,8 +21,8 @@ const (
 // insert a fingerprint into a bucket. Returns true if there was enough space and insertion succeeded.
 // Note it allows inserting the same fingerprint multiple times.
 func (b *bucket) insert(fp fingerprint) bool {
-	if i := b.index(nullFp); i != 4 {
-		b[i] = fp
+	if i := findZeros(uint64(*b)); i != 0 {
+		*b |= bucket(fp) << (bits.Len64(i) - fingerprintSizeBits)
 		return true
 	}
 	return false
@@ -31,43 +31,37 @@ func (b *bucket) insert(fp fingerprint) bool {
 // delete a fingerprint from a bucket.
 // Returns true if the fingerprint was present and successfully removed.
 func (b *bucket) delete(fp fingerprint) bool {
-	if i := b.index(fp); i != 4 {
-		b[i] = nullFp
+	if i := findValue(uint64(*b), uint16(fp)); i != 0 {
+		*b &= ^(maxFingerprint << (bits.Len64(i) - fingerprintSizeBits))
 		return true
 	}
 	return false
 }
 
-func (b *bucket) contains(needle fingerprint) bool {
-	return b.index(needle) != 4
+func (b *bucket) swap(i uint64, fp fingerprint) fingerprint {
+	p := (*b) >> (i * fingerprintSizeBits) & maxFingerprint
+	*b = (*b) & ^(maxFingerprint<<(i*fingerprintSizeBits)) | (bucket(fp) << (i * fingerprintSizeBits))
+	return fingerprint(p)
 }
 
-func (b *bucket) index(needle fingerprint) uint8 {
-	if b[0] == needle {
-		return 0
-	}
-	if b[1] == needle {
-		return 1
-	}
-	if b[2] == needle {
-		return 2
-	}
-	if b[3] == needle {
-		return 3
-	}
-	return 4
+func (b *bucket) contains(needle fingerprint) bool {
+	return findValue(uint64(*b), uint16(needle)) != 0
+}
+
+func (b *bucket) nullsCount() uint {
+	return uint(bits.OnesCount64(findZeros(uint64(*b))))
 }
 
 // reset deletes all fingerprints in the bucket.
 func (b *bucket) reset() {
-	*b = [bucketSize]fingerprint{nullFp, nullFp, nullFp, nullFp}
+	*b = 0
 }
 
 func (b *bucket) String() string {
 	var buf bytes.Buffer
 	buf.WriteString("[")
-	for _, by := range b {
-		buf.WriteString(fmt.Sprintf("%5d ", by))
+	for i := 3; i >= 0; i-- {
+		buf.WriteString(fmt.Sprintf("%5d ", ((*b)>>(i*fingerprintSizeBits))&maxFingerprint))
 	}
 	buf.WriteString("]")
 	return buf.String()

--- a/bucket.go
+++ b/bucket.go
@@ -21,11 +21,9 @@ const (
 // insert a fingerprint into a bucket. Returns true if there was enough space and insertion succeeded.
 // Note it allows inserting the same fingerprint multiple times.
 func (b *bucket) insert(fp fingerprint) bool {
-	for i, tfp := range b {
-		if tfp == nullFp {
-			b[i] = fp
-			return true
-		}
+	if i := b.index(nullFp); i != 4 {
+		b[i] = fp
+		return true
 	}
 	return false
 }
@@ -33,29 +31,36 @@ func (b *bucket) insert(fp fingerprint) bool {
 // delete a fingerprint from a bucket.
 // Returns true if the fingerprint was present and successfully removed.
 func (b *bucket) delete(fp fingerprint) bool {
-	for i, tfp := range b {
-		if tfp == fp {
-			b[i] = nullFp
-			return true
-		}
+	if i := b.index(fp); i != 4 {
+		b[i] = nullFp
+		return true
 	}
 	return false
 }
 
 func (b *bucket) contains(needle fingerprint) bool {
-	for _, fp := range b {
-		if fp == needle {
-			return true
-		}
+	return b.index(needle) != 4
+}
+
+func (b *bucket) index(needle fingerprint) uint8 {
+	if b[0] == needle {
+		return 0
 	}
-	return false
+	if b[1] == needle {
+		return 1
+	}
+	if b[2] == needle {
+		return 2
+	}
+	if b[3] == needle {
+		return 3
+	}
+	return 4
 }
 
 // reset deletes all fingerprints in the bucket.
 func (b *bucket) reset() {
-	for i := range b {
-		b[i] = nullFp
-	}
+	*b = [bucketSize]fingerprint{nullFp, nullFp, nullFp, nullFp}
 }
 
 func (b *bucket) String() string {

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -8,12 +8,65 @@ import (
 func TestBucket_Reset(t *testing.T) {
 	var bkt bucket
 	for i := fingerprint(0); i < bucketSize; i++ {
-		bkt[i] = i
+		bkt.insert(i + 1)
 	}
+
 	bkt.reset()
 
 	var want bucket
 	if !reflect.DeepEqual(bkt, want) {
 		t.Errorf("bucket.reset() got %v, want %v", bkt, want)
+	}
+}
+
+func TestBucket_Insert(t *testing.T) {
+	var bkt bucket
+	for i := fingerprint(0); i < bucketSize; i++ {
+		if !bkt.insert(i + 1) {
+			t.Error("bucket insert failed")
+		}
+	}
+	if bkt.insert(5) {
+		t.Error("expected bucket insert to fail after overflow")
+	}
+}
+
+func TestBucket_Delete(t *testing.T) {
+	var bkt bucket
+	for i := fingerprint(0); i < bucketSize; i++ {
+		bkt.insert(i + 1)
+	}
+
+	for i := fingerprint(0); i < bucketSize; i++ {
+		if !bkt.delete(i + 1) {
+			t.Error("bucket delete failed")
+		}
+		if !bkt.insert(i + 1) {
+			t.Error("bucket insert after delete failed")
+		}
+	}
+}
+
+func TestBucket_Swap(t *testing.T) {
+	var bkt bucket
+	bkt.insert(123)
+	if prev := bkt.swap(3, 321); prev != 123 {
+		t.Errorf("swap returned unexpected value %d", prev)
+	}
+	if !bkt.contains(321) {
+		t.Errorf("contains after swap failed")
+	}
+}
+
+func TestBucket_Contains(t *testing.T) {
+	var bkt bucket
+	for i := fingerprint(0); i < bucketSize; i++ {
+		bkt.insert(i + 1)
+	}
+
+	for i := fingerprint(0); i < bucketSize; i++ {
+		if !bkt.contains(i + 1) {
+			t.Error("bucket contains failed")
+		}
 	}
 }

--- a/cuckoofilter.go
+++ b/cuckoofilter.go
@@ -26,10 +26,15 @@ type Filter struct {
 // A capacity of 1000000 is a normal default, which allocates
 // about ~2MB on 64-bit machines.
 func NewFilter(numElements uint) *Filter {
-	numBuckets := getNextPow2(uint64(numElements / bucketSize))
-	if float64(numElements)/float64(numBuckets*bucketSize) > 0.96 {
-		numBuckets <<= 1
+	paddedNumElements := getNextPow2(uint64(numElements/bucketSize)) * bucketSize
+	if float64(numElements)/float64(paddedNumElements) > 0.96 {
+		paddedNumElements <<= 1
 	}
+	return NewFilterWithoutPadding(paddedNumElements)
+}
+
+func NewFilterWithoutPadding(numElements uint) *Filter {
+	numBuckets := getNextPow2(uint64(numElements / bucketSize))
 	if numBuckets == 0 {
 		numBuckets = 1
 	}

--- a/cuckoofilter_test.go
+++ b/cuckoofilter_test.go
@@ -239,15 +239,9 @@ func TestDeleteMultipleSame(t *testing.T) {
 
 func TestEncodeDecode(t *testing.T) {
 	cf := NewFilter(10)
-	cf.Insert([]byte{1})
-	cf.Insert([]byte{2})
-	cf.Insert([]byte{3})
-	cf.Insert([]byte{4})
-	cf.Insert([]byte{5})
-	cf.Insert([]byte{6})
-	cf.Insert([]byte{7})
-	cf.Insert([]byte{8})
-	cf.Insert([]byte{9})
+	for i := 0; i < 16; i++ {
+		cf.Insert([]byte{byte(i)})
+	}
 	encoded := cf.Encode()
 	got, err := Decode(encoded)
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package cuckoo_test
 import (
 	"fmt"
 
-	cuckoo "github.com/panmari/cuckoofilter"
+	cuckoo "github.com/livekit/cuckoofilter"
 )
 
 func Example() {

--- a/example_threadsafe_test.go
+++ b/example_threadsafe_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	cuckoo "github.com/panmari/cuckoofilter"
+	cuckoo "github.com/livekit/cuckoofilter"
 )
 
 // Small wrapper around cuckoo filter making it thread safe.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/panmari/cuckoofilter
+module github.com/livekit/cuckoofilter
 
 go 1.15
 
@@ -7,3 +7,5 @@ require (
 	github.com/zeebo/wyhash v0.0.1
 	github.com/zeebo/xxh3 v1.0.2
 )
+
+require github.com/klauspost/cpuid/v2 v2.0.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/panmari/cuckoofilter
 go 1.15
 
 require (
-	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165
 	github.com/google/go-cmp v0.5.9
+	github.com/zeebo/wyhash v0.0.1
+	github.com/zeebo/xxh3 v1.0.2
 )

--- a/go.sum
+++ b/go.sum
@@ -3,7 +3,6 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
-github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/wyhash v0.0.1 h1:VEByEMek3iHhV65CgG3SRAWVtg/6TcmbEKj5jPOKDrc=
 github.com/zeebo/wyhash v0.0.1/go.mod h1:Ti+OwfNtM5AZiYAL0kOPIfliqDP5c0VtOnnMAqzuuZk=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,10 @@
-github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 h1:BS21ZUJ/B5X2UVUbczfmdWH7GapPWAhxcMsDnjJTU1E=
-github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/wyhash v0.0.1 h1:VEByEMek3iHhV65CgG3SRAWVtg/6TcmbEKj5jPOKDrc=
+github.com/zeebo/wyhash v0.0.1/go.mod h1:Ti+OwfNtM5AZiYAL0kOPIfliqDP5c0VtOnnMAqzuuZk=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=

--- a/util.go
+++ b/util.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"math/bits"
 
-	"github.com/zeebo/wyhash"
 	"github.com/zeebo/xxh3"
 )
 
@@ -14,16 +13,8 @@ func init() {
 	b := make([]byte, 2)
 	for i := 0; i < maxFingerprint+1; i++ {
 		binary.LittleEndian.PutUint16(b, uint16(i))
-		altHash[i] = (uint(xxh3.Hash(b)))
+		altHash[i] = uint(xxh3.Hash(b))
 	}
-}
-
-// randi returns either i1 or i2 randomly.
-func randi(rng *wyhash.RNG, i1, i2 uint) uint {
-	if rng.Uint64()&1 == 0 {
-		return i1
-	}
-	return i2
 }
 
 func getAltIndex(fp fingerprint, i uint, bucketIndexMask uint) uint {
@@ -49,4 +40,14 @@ func getIndexAndFingerprint(data []byte, bucketIndexMask uint) (uint, fingerprin
 
 func getNextPow2(n uint64) uint {
 	return uint(1 << bits.Len64(n-1))
+}
+
+// SEE: https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
+func findZeros(v uint64) uint64 {
+	return ^((((v & 0x7FFF7FFF7FFF7FFF) + 0x7FFF7FFF7FFF7FFF) | v) | 0x7FFF7FFF7FFF7FFF)
+}
+
+// SEE: https://graphics.stanford.edu/~seander/bithacks.html#ValueInWord
+func findValue(x uint64, n uint16) uint64 {
+	return findZeros(x ^ (^uint64(0) / (1<<16 - 1) * uint64(n)))
 }


### PR DESCRIPTION
add the improvement to `getAltIndex` by @MeteorsLiu from their abandoned pr. 

simplify `getNextPow2`

use a per filter rng for `randi` to avoid contention

preallocate temporary read/write buffer in encode/decode

pack buckets into uint64

before
```
goos: darwin
goarch: arm64
pkg: github.com/panmari/cuckoofilter
BenchmarkFilter_Reset
BenchmarkFilter_Reset-10     	  133612	      8374 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilter_Insert
BenchmarkFilter_Insert-10    	54015536	        22.35 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilter_Lookup
BenchmarkFilter_Lookup-10    	68751163	        17.63 ns/op	       0 B/op	       0 allocs/op
PASS
```
after
```
goos: darwin
goarch: arm64
pkg: github.com/panmari/cuckoofilter
BenchmarkFilter_Reset
BenchmarkFilter_Reset-10     	  885447	      1340 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilter_Insert
BenchmarkFilter_Insert-10    	140478770	         8.548 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilter_Lookup
BenchmarkFilter_Lookup-10    	120644037	         9.868 ns/op	       0 B/op	       0 allocs/op
```