### PR TITLE
Eliminate use of stdlib rand

### DIFF
--- a/cuckoofilter.go
+++ b/cuckoofilter.go
@@ -82,16 +82,18 @@ func (cf *Filter) Insert(data []byte) bool {
 	return cf.reinsert(fp, cf.Coinflip(i1, i2))
 }
 
-// this isn't perfectly uniform, but it's good enough for our purposes since
-// n is on the order of 10^6 and our rng is 63 bits (10^19); this means the
-// bias is on the order of 10^-13. For our use case, that's well below the
-// noise floor.
+// Using % isn't *perfectly* uniform, but it really only matters when n is a
+// significant fraction of the rng's range. It's more than good enough for our
+// purposes since n is on the order of 10^6 and our rng is 63 bits (10^19); this
+// means the bias is on the order of 10^-13. For our use case, that's well below
+// the noise floor.
 func (cf *Filter) Intn(n int) int {
 	// we need to make sure it's strictly positive, so mask off the sign bit
 	return int(cf.rng.Next()&0x7FFF_FFFF_FFFF_FFFF) % n
 }
 
-// Coinflip returns either i1 or i2 randomly.
+// Coinflip returns either i1 or i2 randomly by examining the least significant
+// bit of the RNG.
 func (cf Filter) Coinflip(i1, i2 uint) uint {
 	if cf.rng.Next()&0x1 == 0 {
 		return i1

--- a/cuckoofilter_test.go
+++ b/cuckoofilter_test.go
@@ -250,7 +250,7 @@ func TestEncodeDecode(t *testing.T) {
 	}
 }
 
-func TestFilter_randi(t *testing.T) {
+func TestFilter_Coinflip(t *testing.T) {
 	cf := NewFilter(8)
 	yes := 0
 	for i := 0; i < 1000000; i++ {
@@ -258,6 +258,7 @@ func TestFilter_randi(t *testing.T) {
 			yes++
 		}
 	}
+	// See below -- we're checking that we're within 1% of the expected value.
 	if yes < 499000 || yes > 501000 {
 		t.Errorf("yes: %d, expected 500000", yes)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.15
 
 require (
 	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165
+	github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371
 	github.com/google/go-cmp v0.5.9
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 h1:BS21ZUJ/B5X2UVUbczfmdWH7GapPWAhxcMsDnjJTU1E=
 github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
+github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371 h1:bz5ApY1kzFBvw3yckuyRBCtqGvprWrKswYK468nm+Gs=
+github.com/dgryski/go-wyhash v0.0.0-20191203203029-c4841ae36371/go.mod h1:/ENMIO1SQeJ5YQeUWWpbX8f+bS8INHrrhFjXgEqi4LA=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/util.go
+++ b/util.go
@@ -2,18 +2,10 @@ package cuckoo
 
 import (
 	"encoding/binary"
-	"math/rand"
+	"math/bits"
 
 	metro "github.com/dgryski/go-metro"
 )
-
-// randi returns either i1 or i2 randomly.
-func randi(i1, i2 uint) uint {
-	if rand.Int31()%2 == 0 {
-		return i1
-	}
-	return i2
-}
 
 func getAltIndex(fp fingerprint, i uint, bucketIndexMask uint) uint {
 	b := make([]byte, 2)
@@ -40,13 +32,5 @@ func getIndexAndFingerprint(data []byte, bucketIndexMask uint) (uint, fingerprin
 }
 
 func getNextPow2(n uint64) uint {
-	n--
-	n |= n >> 1
-	n |= n >> 2
-	n |= n >> 4
-	n |= n >> 8
-	n |= n >> 16
-	n |= n >> 32
-	n++
-	return uint(n)
+	return uint(1 << bits.Len64(n-1))
 }


### PR DESCRIPTION
I've been using this project in [one of mine](https://github.com/honeycombio/refinery/blob/main/collect/cache/cuckoo.go) as a way to track traceIDs that have traversed our sampling proxy. In doing some profiling under heavy load, we've realized that there's a significant performance block through the use of the default global random number generator provided by Go's standard library. The global `math.rand` takes a lock on every invocation and can be needlessly expensive.

PR #12 addresses that issue as well as others, but the submitter has been asked to break it up into smaller pieces. In particular, it modifies Encode and Decode for better performance, but as my use case doesn't use those, I haven't touched them here. 

In a similar fashion to that, this PR uses a fast, well-distributed hashing algorithm (wyhash) as a pseudorandom number generator, and attaches it to the filter object so that no additional locks are needed. The particular version of wyhash used here is different from that in #12 and was mainly chosen because I have experience with it and am already using it elsewhere in my project.

For now, we're going to depend on our own fork, but I'd much rather see the issue addressed upstream, either by merging this, #12, or some other variant. 

Another option would be to allow an RNG matching an interface to be injected rather than depending on the global one. This would also make certain kinds of testing easier.

This PR includes:
- Move the RNG into a member of the filter
- Implement Intn and CoinFlip functions on it
- Write some probabalistic tests for them to verify they're reasonably well-distributed
- Call them in place of math.rand functions
- Replace custom bitbanging in `getNextPow2` with Go's standard library for it

Thank you for this library!
